### PR TITLE
Update HTTPretty version to something current

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ requests>=1.2.3,<=2.0.1
 rsa==3.1.4
 simplejson==3.6.5
 argparse==1.2.1
-httpretty>=0.7.0,<=0.8.6
+httpretty>=0.9.6
 paramiko>=1.10.0
 PyYAML>=3.10
 coverage==3.7.1


### PR DESCRIPTION
The previous commit that changed the HTTPretty version, https://github.com/boto/boto/commit/cf7ede6acc5109b894a2251ced753984cffff991, mentioned that 0.8.7 caused tests to hang, but it provided no bug link, logs, etc.  So, after seeing passing TravisCI tests when using v0.9.6, I can only assume that this new version of HTTPretty fixes whatever bugs were occurring when that previous commit was added.