### PR TITLE
Replacing `get_utf8_value` method with wrappers to `six.ensure_` methods

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -383,7 +383,7 @@ class HmacAuthV4Handler(AuthHandler, HmacKeys):
         parameter_names = sorted(http_request.params.keys())
         pairs = []
         for pname in parameter_names:
-            pval = boto.utils.get_utf8_value(http_request.params[pname])
+            pval = boto.utils.val_to_str(http_request.params[pname])
             pairs.append(urllib.parse.quote(pname, safe=''.encode('ascii')) +
                          '=' +
                          urllib.parse.quote(pval, safe='-_~'.encode('ascii')))
@@ -396,7 +396,7 @@ class HmacAuthV4Handler(AuthHandler, HmacKeys):
             return ""
         l = []
         for param in sorted(http_request.params):
-            value = boto.utils.get_utf8_value(http_request.params[param])
+            value = boto.utils.val_to_str(http_request.params[param])
             l.append('%s=%s' % (urllib.parse.quote(param, safe='-_.~'),
                                 urllib.parse.quote(value, safe='-_.~')))
         return '&'.join(l)
@@ -623,7 +623,7 @@ class S3HmacAuthV4Handler(HmacAuthV4Handler, AuthHandler):
         # query string.
         l = []
         for param in sorted(http_request.params):
-            value = boto.utils.get_utf8_value(http_request.params[param])
+            value = boto.utils.val_to_str(http_request.params[param])
             l.append('%s=%s' % (urllib.parse.quote(param, safe='-_.~'),
                                 urllib.parse.quote(value, safe='-_.~')))
         return '&'.join(l)
@@ -836,7 +836,7 @@ class STSAnonHandler(AuthHandler):
         keys.sort(key=lambda x: x.lower())
         pairs = []
         for key in keys:
-            val = boto.utils.get_utf8_value(params[key])
+            val = boto.utils.val_to_str(params[key])
             pairs.append(key + '=' + self._escape_value(six.ensure_str(val)))
         return '&'.join(pairs)
 
@@ -897,7 +897,7 @@ class QuerySignatureV0AuthHandler(QuerySignatureHelper, AuthHandler):
         keys.sort(cmp=lambda x, y: cmp(x.lower(), y.lower()))
         pairs = []
         for key in keys:
-            val = boto.utils.get_utf8_value(params[key])
+            val = boto.utils.val_to_str(params[key])
             pairs.append(key + '=' + urllib.parse.quote(val))
         qs = '&'.join(pairs)
         return (qs, base64.b64encode(hmac.digest()))
@@ -924,7 +924,7 @@ class QuerySignatureV1AuthHandler(QuerySignatureHelper, AuthHandler):
         pairs = []
         for key in keys:
             hmac.update(key.encode('utf-8'))
-            val = boto.utils.get_utf8_value(params[key])
+            val = boto.utils.val_to_binary(params[key])
             hmac.update(val)
             pairs.append(key + '=' + urllib.parse.quote(val))
         qs = '&'.join(pairs)
@@ -948,7 +948,7 @@ class QuerySignatureV2AuthHandler(QuerySignatureHelper, AuthHandler):
         keys = sorted(params.keys())
         pairs = []
         for key in keys:
-            val = boto.utils.get_utf8_value(params[key])
+            val = boto.utils.val_to_str(params[key])
             pairs.append(urllib.parse.quote(key, safe='') + '=' +
                          urllib.parse.quote(val, safe='-_~'))
         qs = '&'.join(pairs)

--- a/boto/connection.py
+++ b/boto/connection.py
@@ -1106,7 +1106,7 @@ class AWSQueryConnection(AWSAuthConnection):
         return []
 
     def get_utf8_value(self, value):
-        return boto.utils.get_utf8_value(value)
+        return boto.utils.val_to_str(value)
 
     def make_request(self, action, params=None, path='/', verb='GET'):
         http_request = self.build_base_http_request(verb, path, None,

--- a/boto/gs/bucket.py
+++ b/boto/gs/bucket.py
@@ -40,7 +40,7 @@ from boto.gs.lifecycle import LifecycleConfig
 from boto.gs.key import Key as GSKey
 from boto.s3.acl import Policy
 from boto.s3.bucket import Bucket as S3Bucket
-from boto.utils import get_utf8_value
+from boto.utils import val_to_str
 from boto.compat import quote
 from boto.compat import six
 
@@ -883,7 +883,7 @@ class Bucket(S3Bucket):
 
         body = self.WebsiteBody % (main_page_frag, error_frag)
         response = self.connection.make_request(
-            'PUT', get_utf8_value(self.name), data=get_utf8_value(body),
+            'PUT', val_to_str(self.name), data=val_to_str(body),
             query_args='websiteConfig', headers=headers)
         body = response.read()
         if response.status == 200:

--- a/boto/gs/connection.py
+++ b/boto/gs/connection.py
@@ -23,7 +23,7 @@ from boto.gs.bucket import Bucket
 from boto.s3.connection import S3Connection
 from boto.s3.connection import SubdomainCallingFormat
 from boto.s3.connection import check_lowercase_bucketname
-from boto.utils import get_utf8_value
+from boto.utils import val_to_str
 
 class Location(object):
     DEFAULT = 'US'
@@ -91,8 +91,8 @@ class GSConnection(S3Connection):
         data = ('<CreateBucketConfiguration>%s%s</CreateBucketConfiguration>'
                  % (location_elem, storage_class_elem))
         response = self.make_request(
-            'PUT', get_utf8_value(bucket_name), headers=headers,
-            data=get_utf8_value(data))
+            'PUT', val_to_str(bucket_name), headers=headers,
+            data=val_to_str(data))
         body = response.read()
         if response.status == 409:
             raise self.provider.storage_create_error(

--- a/boto/gs/key.py
+++ b/boto/gs/key.py
@@ -29,7 +29,7 @@ from boto.exception import BotoClientError
 from boto.s3.key import Key as S3Key
 from boto.s3.keyfile import KeyFile
 from boto.utils import compute_hash
-from boto.utils import get_utf8_value
+from boto.utils import val_to_str
 
 class Key(S3Key):
     """
@@ -707,7 +707,7 @@ class Key(S3Key):
         self.md5 = None
         self.base64md5 = None
 
-        fp = StringIO(get_utf8_value(s))
+        fp = StringIO(val_to_str(s))
         r = self.set_contents_from_file(fp, headers, replace, cb, num_cb,
                                         policy, md5,
                                         if_generation=if_generation)

--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -852,7 +852,7 @@ class Bucket(object):
             if isinstance(src_key_name, bytes):
                 src_key_name = src_key_name.decode('utf-8')
         else:
-            src_key_name = boto.utils.get_utf8_value(src_key_name)
+            src_key_name = boto.utils.val_to_str(src_key_name)
         if preserve_acl:
             if self.name == src_bucket_name:
                 src_bucket = self

--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -88,7 +88,7 @@ class _CallingFormat(object):
             return self.get_bucket_server(server, bucket)
 
     def build_auth_path(self, bucket, key=''):
-        key = boto.utils.get_utf8_value(key)
+        key = boto.utils.val_to_str(key)
         if isinstance(bucket, bytes):
             bucket = bucket.decode('utf-8')
         path = ''
@@ -97,7 +97,7 @@ class _CallingFormat(object):
         return path + '/%s' % urllib.parse.quote(key)
 
     def build_path_base(self, bucket, key=''):
-        key = boto.utils.get_utf8_value(key)
+        key = boto.utils.val_to_str(key)
         return '/%s' % urllib.parse.quote(key)
 
 
@@ -121,7 +121,7 @@ class OrdinaryCallingFormat(_CallingFormat):
         return server
 
     def build_path_base(self, bucket, key=''):
-        key = boto.utils.get_utf8_value(key)
+        key = boto.utils.val_to_str(key)
         path_base = '/'
         if bucket:
             path_base += "%s/" % bucket

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -46,7 +46,7 @@ import boto.utils
 from boto.utils import compute_md5, compute_hash
 from boto.utils import find_matching_headers
 from boto.utils import merge_headers_by_name
-
+from boto.utils import print_to_fd
 
 class Key(object):
     """
@@ -1553,7 +1553,7 @@ class Key(object):
             cb(data_len, cb_size)
         try:
             for key_bytes in self:
-                print(key_bytes, file=fp, end='')
+                print_to_fd(six.ensure_binary(key_bytes), file=fp, end=b'')
                 data_len += len(key_bytes)
                 for alg in digesters:
                     digesters[alg].update(key_bytes)

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -50,6 +50,7 @@ import random
 import smtplib
 import datetime
 import re
+import io
 import email.mime.multipart
 import email.mime.base
 import email.mime.text

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -58,6 +58,7 @@ import email.encoders
 import gzip
 import threading
 import locale
+import sys
 from boto.compat import six, StringIO, urllib, encodebytes
 
 from contextlib import contextmanager
@@ -1131,7 +1132,7 @@ def print_to_fd(*objects, **kwargs):
     Returns the above kwargs of the above types.
     """
     expected_keywords = collections.OrderedDict([
-http://blog.danskingdom.com/allow-others-to-run-your-powershell-scripts-from-a-batch-file-they-will-love-you-for-it/      ('sep', ' '),
+      ('sep', ' '),
       ('end', '\n'),
       ('file', sys.stdout)])
 

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -1118,81 +1118,81 @@ def parse_host(hostname):
         return hostname.split(':', 1)[0]
 
 def print_to_fd(*objects, **kwargs):
-  """A Python 2/3 compatible analogue to the print function.
-  This function writes text to a file descriptor as the
-  builtin print function would, favoring unicode encoding.
-  Aguments and return values are the same as documented in
-  the Python 2 print function.
-  """
-  def _get_args(**kwargs):
-    """Validates keyword arguments that would be used in Print
-    Valid keyword arguments, mirroring print(), are 'sep',
-    'end', and 'file'. These must be of types string, string,
-    and file / file interface respectively.
-    Returns the above kwargs of the above types.
+    """A Python 2/3 compatible analogue to the print function.
+
+    This function writes text to a file descriptor as the
+    builtin print function would, favoring utf-8 encoding.
+    Arguments and return values are the same as documented in
+    the Python 2 print function.
     """
-    expected_keywords = collections.OrderedDict([
-      ('sep', ' '),
-      ('end', '\n'),
-      ('file', sys.stdout)])
+    def _get_args(**kwargs):
+        """Validates keyword arguments that would be used in Print
+        Valid keyword arguments, mirroring print(), are 'sep',
+        'end', and 'file'. These must be of types string, string,
+        and file / file interface respectively.
+        Returns the above kwargs of the above types.
+        """
+        expected_keywords = collections.OrderedDict([
+            ('sep', ' '),
+            ('end', '\n'),
+            ('file', sys.stdout)])
 
-    for key, value in kwargs.items():
-      if key not in expected_keywords:
-        error_msg = (
-          '{} is not a valid keyword argument. '
-          'Please use one of: {}')
-        raise KeyError(
-          error_msg.format(
-            key,
-            ' '.join(expected_keywords.keys())))
-      else:
-        expected_keywords[key] = value
+        for key, value in kwargs.items():
+            if key not in expected_keywords:
+                error_msg = (
+                    '{} is not a valid keyword argument. '
+                    'Please use one of: {}')
+                raise KeyError(
+                    error_msg.format(
+                        key,
+                        ' '.join(expected_keywords.keys())))
+            else:
+                expected_keywords[key] = value
 
-    return expected_keywords.values()
+        return expected_keywords.values()
 
+    def _get_byte_strings(*objects):
+        """Gets a `bytes` string for each item in list of printable objects."""
+        byte_objects = []
+        for item in objects:
+            if not isinstance(item, (six.binary_type, six.text_type)):
+                # If the item wasn't bytes or unicode, its __str__ method
+                # should return one of those types.
+                item = str(item)
 
-  def _get_byte_strings(*objects):
-    """Gets a `bytes` string for each item in a list of printable objects."""
-    byte_objects = []
-    for item in objects:
-      if not isinstance(item, (six.binary_type, six.text_type)):
-        # If the item wasn't bytes or unicode, its __str__ method
-        # should return one of those types.
-        item = str(item)
+            if isinstance(item, six.binary_type):
+                byte_objects.append(item)
+            else:
+                # The item should be unicode. If it's not, ensure_binary()
+                # will throw a TypeError.
+                byte_objects.append(six.ensure_binary(item))
+        return byte_objects
 
-      if isinstance(item, six.binary_type):
-        byte_objects.append(item)
-      else:
-        # The item should be unicode. If it's not, ensure_binary()
-        # will throw a TypeError.
-        byte_objects.append(six.ensure_binary(item))
-    return byte_objects
-
-  sep, end, file = _get_args(**kwargs)
-  sep = six.ensure_binary(sep)
-  end = six.ensure_binary(end)
-  data = _get_byte_strings(*objects)
-  data = sep.join(data)
-  data += end
-  write_to_fd(file, data)
+    sep, end, file = _get_args(**kwargs)
+    sep = six.ensure_binary(sep)
+    end = six.ensure_binary(end)
+    data = _get_byte_strings(*objects)
+    data = sep.join(data)
+    data += end
+    write_to_fd(file, data)
 
 
 def write_to_fd(fd, data):
-  """Write given data to given file descriptor, doing any conversions needed"""
-  if six.PY2:
-    fd.write(data)
-    return
-  # PY3 logic:
-  if isinstance(data, bytes):
-    if (hasattr(fd, 'mode') and 'b' in fd.mode) or isinstance(fd, io.BytesIO):
-      fd.write(data)
-    elif hasattr(fd, 'buffer'):
-      fd.buffer.write(data)
+    """Write given data to given file descriptor, doing any conversions needed"""
+    if six.PY2:
+        fd.write(data)
+        return
+    # PY3 logic:
+    if isinstance(data, bytes):
+        if ((hasattr(fd, 'mode') and 'b' in fd.mode) or
+                isinstance(fd, io.BytesIO)):
+            fd.write(data)
+        elif hasattr(fd, 'buffer'):
+            fd.buffer.write(data)
+        else:
+            fd.write(six.ensure_text(data))
+    elif 'b' in fd.mode:
+        fd.write(six.ensure_binary(data))
     else:
-      fd.write(six.ensure_text(data))
-  elif 'b' in fd.mode:
-    fd.write(six.ensure_binary(data))
-  else:
-    fd.write(data)
-
+        fd.write(data)
 

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -44,6 +44,7 @@ import time
 import logging.handlers
 import boto
 import boto.provider
+import collections
 import tempfile
 import random
 import smtplib
@@ -1130,7 +1131,7 @@ def print_to_fd(*objects, **kwargs):
     Returns the above kwargs of the above types.
     """
     expected_keywords = collections.OrderedDict([
-      ('sep', ' '),
+http://blog.danskingdom.com/allow-others-to-run-your-powershell-scripts-from-a-batch-file-they-will-love-you-for-it/      ('sep', ' '),
       ('end', '\n'),
       ('file', sys.stdout)])
 

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -859,17 +859,35 @@ def notify(subject, body=None, html_body=None, to_string=None,
             boto.log.exception('notify failed')
 
 
-def get_utf8_value(value):
-    if isinstance(value, bytes):
-        value.decode('utf-8')
-        return value
-    if not isinstance(value, six.string_types):
-        value = six.text_type(value)
+def _TryEncodings(string, conv_method):
+    new_string = None
+    encodings = ["utf-8", "latin-1", "ascii", "cp1252"]
 
-    if isinstance(value, six.text_type):
-        value = value.encode('utf-8')
+    def _try_enc(string, encoding):
+        try:
+            return conv_method(string, encoding)
+        except TypeError:
+            return conv_method(str(string), encoding)
+        except:
+            return None
 
-    return value
+    enc_index = 0
+    while new_string is None and enc_index < len(encodings):
+        new_string = _try_enc(string, encodings[enc_index])
+        enc_index += 1
+    return new_string if not None else string
+
+
+def val_to_binary(val):
+    return _TryEncodings(val, six.ensure_binary)
+
+
+def val_to_text(val):
+    return _TryEncodings(val, six.ensure_text)
+
+
+def val_to_str(val):
+    return _TryEncodings(val, six.ensure_str)
 
 
 def mklist(value):

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -1115,3 +1115,82 @@ def parse_host(hostname):
     else:
         return hostname.split(':', 1)[0]
 
+def print_to_fd(*objects, **kwargs):
+  """A Python 2/3 compatible analogue to the print function.
+  This function writes text to a file descriptor as the
+  builtin print function would, favoring unicode encoding.
+  Aguments and return values are the same as documented in
+  the Python 2 print function.
+  """
+  def _get_args(**kwargs):
+    """Validates keyword arguments that would be used in Print
+    Valid keyword arguments, mirroring print(), are 'sep',
+    'end', and 'file'. These must be of types string, string,
+    and file / file interface respectively.
+    Returns the above kwargs of the above types.
+    """
+    expected_keywords = collections.OrderedDict([
+      ('sep', ' '),
+      ('end', '\n'),
+      ('file', sys.stdout)])
+
+    for key, value in kwargs.items():
+      if key not in expected_keywords:
+        error_msg = (
+          '{} is not a valid keyword argument. '
+          'Please use one of: {}')
+        raise KeyError(
+          error_msg.format(
+            key,
+            ' '.join(expected_keywords.keys())))
+      else:
+        expected_keywords[key] = value
+
+    return expected_keywords.values()
+
+
+  def _get_byte_strings(*objects):
+    """Gets a `bytes` string for each item in a list of printable objects."""
+    byte_objects = []
+    for item in objects:
+      if not isinstance(item, (six.binary_type, six.text_type)):
+        # If the item wasn't bytes or unicode, its __str__ method
+        # should return one of those types.
+        item = str(item)
+
+      if isinstance(item, six.binary_type):
+        byte_objects.append(item)
+      else:
+        # The item should be unicode. If it's not, ensure_binary()
+        # will throw a TypeError.
+        byte_objects.append(six.ensure_binary(item))
+    return byte_objects
+
+  sep, end, file = _get_args(**kwargs)
+  sep = six.ensure_binary(sep)
+  end = six.ensure_binary(end)
+  data = _get_byte_strings(*objects)
+  data = sep.join(data)
+  data += end
+  write_to_fd(file, data)
+
+
+def write_to_fd(fd, data):
+  """Write given data to given file descriptor, doing any conversions needed"""
+  if six.PY2:
+    fd.write(data)
+    return
+  # PY3 logic:
+  if isinstance(data, bytes):
+    if (hasattr(fd, 'mode') and 'b' in fd.mode) or isinstance(fd, io.BytesIO):
+      fd.write(data)
+    elif hasattr(fd, 'buffer'):
+      fd.buffer.write(data)
+    else:
+      fd.write(six.ensure_text(data))
+  elif 'b' in fd.mode:
+    fd.write(six.ensure_binary(data))
+  else:
+    fd.write(data)
+
+


### PR DESCRIPTION
Wrapper methods will attempt a list of common encodings, combined with
the appropriate `six.ensure_` method. Wrapper will also attempt to
handle non-string types--such as int and None.